### PR TITLE
Fix Benchmark Again

### DIFF
--- a/TrainingGym/benchmark.py
+++ b/TrainingGym/benchmark.py
@@ -108,7 +108,7 @@ def benchmark():
             if not controlled_lights[i]['train']:
                 del controlled_lights[i]
         env = SumoEnvParallel(config_params['test_steps'], True, controlled_lights[0]['light_name'],
-                              collect_statistics=False)
+                              collect_statistics=False, seed=SEED)
         model = PPO2.load(f'Scenarios/{config_params["model_save_path"]}/PPO2_{controlled_lights[0]["light_name"]}')
         obs = env.reset()
 

--- a/TrainingGym/env/SumoEnvParallel.py
+++ b/TrainingGym/env/SumoEnvParallel.py
@@ -60,9 +60,10 @@ def find_attr_in_list(lst, attr, value):
 
 
 class SumoEnvParallel(gym.Env, BaseCallback):
-    def __init__(self, steps_per_episode, use_sumo_gui, controlled_light_name, collect_statistics):
+    def __init__(self, steps_per_episode, use_sumo_gui, controlled_light_name, collect_statistics, seed=-1):
         super(SumoEnvParallel, self).__init__()
-
+        if seed != -1:
+            load_options[load_options.index("--seed") + 1] = str(seed)
         # Environment parameters
         self.steps_per_episode = steps_per_episode
         self.is_done = False


### PR DESCRIPTION
This removes using the accumulated wait time of vehicles. This means the training_config shouldn't need to be modified when benchmarking. 

Also added support for set seed ~glitchless speed~runs of the benchmark when using the trained agents so it's just a parameter to change before running like the other benchmark. 

Benchmarks on the same seed have the same results with the previous implementation which should indicate the correctness of these changes. 

I would recommend trying on a trained agent to see if the set-seed broke anything (though I believe it shouldn't). 

For reference stats on seed 100:
```
Average Overflow (%): 34.496995550955
Average Queue Length (Num Cars): 4.095854700854701
Average Delay: 20.41360136869119
```